### PR TITLE
Dynamic titles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,8 @@ params:
     # Main hero title
     title: DataEngConfAU Sydney
     # Hero subtitle (optional)"
-    subtitle: "Conference: Tuesday, 4th of August 2020. \n Workshops: Monday, 3rd of August 2020. "
+    subtitle: "Conference: Tuesday, 4th of August 2020."
+    subtitle2: "Workshops: Monday, 3rd of August 2020."
     # Button text
     buttontext: Learn more
     # Where the main hero button links to

--- a/themes/leo-fresh/assets/fresh/partials/_hero.scss
+++ b/themes/leo-fresh/assets/fresh/partials/_hero.scss
@@ -10,6 +10,12 @@ Hero styles
         font-family: 'Open Sans', sans-serif;
     }
     .title {
+        @media (max-width: 840px) {
+            font-size: 2rem !important;
+        }
+        @media (max-width: 1200px) {
+            font-size: 2.5rem;
+        }
         &.is-bold {
             font-weight: 700;
         }

--- a/themes/leo-fresh/assets/fresh/partials/_sections.scss
+++ b/themes/leo-fresh/assets/fresh/partials/_sections.scss
@@ -30,6 +30,14 @@ Section Styles
         font-family: 'Open Sans', sans-serif;
 
     }
+    .title {
+        @media (max-width: 840px) {
+            font-size: 2rem !important;
+        }
+        @media (max-width: 1200px) {
+            font-size: 2.5rem;
+        }
+    }
     .subtitle {
         &.is-muted {
             color: $muted-grey;

--- a/themes/leo-fresh/layouts/partials/hero-body.html
+++ b/themes/leo-fresh/layouts/partials/hero-body.html
@@ -1,6 +1,7 @@
 {{- $hero       := .Site.Params.hero }}
 {{- $title      := index $hero "title" }}
 {{- $subtitle   := index $hero "subtitle" }}
+{{- $subtitle2   := index $hero "subtitle2" }}
 {{- $buttonText := index $hero "buttontext" }}
 {{- $buttonLink := index $hero "buttonlink" }}
 {{- $image      := index $hero "image" }}
@@ -8,10 +9,15 @@
   <div class="container">
     <div class="columns is-vcentered">
       <div class="column is-5 is-offset-1 landing-caption">
-        <h1 class="title is-1 is-bold is-spaced">
+        <h1 class="title is-1 is-bold is-spaced" style="word-spacing: 100vw;">
           {{ $title }}
         </h1>
         {{ with $subtitle }}
+        <h2 class="subtitle is-5 is-muted" style="margin-bottom: 0px;">
+          {{ . | markdownify}}
+        </h2>
+        {{ end }}
+        {{ with $subtitle2 }}
         <h2 class="subtitle is-5 is-muted">
           {{ . | markdownify}}
         </h2>

--- a/themes/leo-fresh/layouts/partials/meta.html
+++ b/themes/leo-fresh/layouts/partials/meta.html
@@ -2,7 +2,7 @@
 {{ if eq .Site.Params.openGraph true }}
 {{ template "_internal/opengraph.html" . }}
 {{ end }}
-<meta name="description" content="{{ if .Params.summary }}{{ .Params.summary }}{{ else if .Site.Params.Description }}{{ .Site.Params.Description }}{{ else }}Hardcoded description; the author should update :){{ end }}" />
+<meta name="description" content="Data Engineering Conference Australia" />
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
1. Remove hard coded description
2. Dynamic titles
3. I ran through the logic of deployment (e.g. the social icons missing and the font-weights), It appears like something went wrong. Locally both with "hugo server" and "hugo --gc --minify" the correct website is deployed. Tried rebasing and now just working directly off this repository. Is there a way to manually trigger the deployment?